### PR TITLE
Dependency upgrades for 1.0.0 release.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "com.transferwise.envoy:envoy-api"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.0.0] - 2023-02-09
+### Added
+* Disabled dependabot for envoy-api package
+### Changed
+* Bump info.solidsoft.pitest from 1.9.0 to 1.9.11
+* Bump io.grpc:grpc-stub from 1.51.0 to 1.52.1
+* Bump com.google.protobuf:protobuf-java from 3.21.9 to 3.21.12
+* Bump org.projectlombok:lombok from 1.18.24 to 1.18.26
+
 ## [0.9.0] - 2023-02-08
 ### Added
 * First public version.

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
     id "at.zierler.yamlvalidator" version "1.5.0"
     id "com.github.spotbugs" version "5.0.12" apply false
     id "net.ltgt.errorprone" version "3.0.1" apply false
-    id 'info.solidsoft.pitest' version '1.9.0' apply false
+    id 'info.solidsoft.pitest' version '1.9.11' apply false
     id 'org.ajoberstar.grgit' version '4.1.1'
     id 'io.github.gradle-nexus.publish-plugin' version "1.1.0"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.9.0
+version=1.0.0

--- a/wise-envoy-xds-core/build.gradle
+++ b/wise-envoy-xds-core/build.gradle
@@ -20,17 +20,17 @@ pitest {
 }
 
 dependencies {
-    implementation 'com.google.protobuf:protobuf-java-util:3.21.9'
+    implementation 'com.google.protobuf:protobuf-java-util:3.21.12'
     implementation "com.google.guava:guava:31.1-jre"
-    implementation 'io.grpc:grpc-stub:1.51.0'
+    implementation 'io.grpc:grpc-stub:1.52.1'
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     implementation 'com.github.spotbugs:spotbugs-annotations:4.7.3'
     implementation 'org.slf4j:slf4j-api:2.0.4'
     compileOnly 'com.transferwise.envoy:envoy-api:1.17.0' // Users are expected to provide a compatible envoy api
-    compileOnly 'org.projectlombok:lombok:1.18.24'
-    annotationProcessor 'org.projectlombok:lombok:1.18.24'
-    testAnnotationProcessor 'org.projectlombok:lombok:1.18.24'
+    compileOnly 'org.projectlombok:lombok:1.18.26'
+    annotationProcessor 'org.projectlombok:lombok:1.18.26'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.26'
     pitest 'org.pitest:pitest-junit5-plugin:1.1.0'
     testImplementation 'com.transferwise.envoy:envoy-api:1.17.0'
-    testImplementation 'org.projectlombok:lombok:1.18.24'
+    testImplementation 'org.projectlombok:lombok:1.18.26'
 }

--- a/wise-envoy-xds-e2e-tests/build.gradle
+++ b/wise-envoy-xds-e2e-tests/build.gradle
@@ -12,18 +12,18 @@ dependencies {
     implementation "com.google.guava:guava:31.1-jre"
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     implementation 'com.github.spotbugs:spotbugs-annotations:4.7.3'
-    implementation 'com.google.protobuf:protobuf-java:3.21.9'
+    implementation 'com.google.protobuf:protobuf-java:3.21.12'
     implementation 'com.google.protobuf:protobuf-java-util:3.21.9'
-    implementation 'io.grpc:grpc-stub:1.51.0'
+    implementation 'io.grpc:grpc-stub:1.52.1'
     implementation project(':wise-envoy-xds-core')
     implementation project(':wise-envoy-xds-example')
     implementation 'com.transferwise.envoy:envoy-api:1.17.0'
-    implementation 'org.projectlombok:lombok:1.18.24'
+    implementation 'org.projectlombok:lombok:1.18.26'
     implementation 'org.testcontainers:junit-jupiter:1.17.6'
     implementation('org.assertj:assertj-core:3.23.1')
-    compileOnly 'org.projectlombok:lombok:1.18.24'
-    annotationProcessor 'org.projectlombok:lombok:1.18.24'
-    testAnnotationProcessor 'org.projectlombok:lombok:1.18.24'
+    compileOnly 'org.projectlombok:lombok:1.18.26'
+    annotationProcessor 'org.projectlombok:lombok:1.18.26'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.26'
     testImplementation 'org.testcontainers:testcontainers:1.17.6'
     testImplementation 'org.awaitility:awaitility:4.2.0'
 }

--- a/wise-envoy-xds-example/build.gradle
+++ b/wise-envoy-xds-example/build.gradle
@@ -12,12 +12,12 @@ dependencies {
     implementation "com.google.guava:guava:31.1-jre"
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     implementation 'com.github.spotbugs:spotbugs-annotations:4.7.3'
-    implementation 'com.google.protobuf:protobuf-java:3.21.9'
-    implementation 'io.grpc:grpc-stub:1.51.0'
+    implementation 'com.google.protobuf:protobuf-java:3.21.12'
+    implementation 'io.grpc:grpc-stub:1.52.1'
     implementation project(':wise-envoy-xds-core')
     implementation 'ch.qos.logback:logback-classic:1.4.5'
     implementation 'ch.qos.logback:logback-core:1.4.5'
     implementation 'com.transferwise.envoy:envoy-api:1.17.0'
-    compileOnly 'org.projectlombok:lombok:1.18.24'
-    annotationProcessor 'org.projectlombok:lombok:1.18.24'
+    compileOnly 'org.projectlombok:lombok:1.18.26'
+    annotationProcessor 'org.projectlombok:lombok:1.18.26'
 }


### PR DESCRIPTION
## Context
Version 1.0.0 release, includes some dependency updates.
Mostly this is to prove that publishing releases works.

## Changes

* Disabled dependabot for envoy-api package
* Bump info.solidsoft.pitest from 1.9.0 to 1.9.11
* Bump io.grpc:grpc-stub from 1.51.0 to 1.52.1
* Bump com.google.protobuf:protobuf-java from 3.21.9 to 3.21.12
* Bump org.projectlombok:lombok from 1.18.24 to 1.18.26