### PR TITLE
Fix remove after envoy reconnect for delta protocol

### DIFF
--- a/wise-envoy-xds-core/src/main/java/com/transferwise/envoy/xds/DiscoveryService.java
+++ b/wise-envoy-xds-core/src/main/java/com/transferwise/envoy/xds/DiscoveryService.java
@@ -56,6 +56,27 @@ public interface DiscoveryService<RequestT extends Message, StateUpdT> {
     void sendNetworkUpdatePost();
 
     /**
+     * Controls whether removals discovered from a reconnecting delta client's initial_resource_versions
+     * should be delayed for manager-coordinated ADS remove ordering.
+     */
+    default void setDeferInitialResourceVersionRemovals(boolean deferInitialResourceVersionRemovals) {
+    }
+
+    /**
+     * Returns true if this service has removals discovered from a reconnecting delta client's
+     * initial_resource_versions that still need to be sent in ADS remove order.
+     */
+    default boolean hasDeferredReconnectRemovals() {
+        return false;
+    }
+
+    /**
+     * Sends pending removals discovered from a reconnecting delta client's initial_resource_versions.
+     */
+    default void sendDeferredReconnectRemovals() {
+    }
+
+    /**
      * Identifies the specific Discover Service type this instance handles.
      */
     TypeUrl getTypeUrl();

--- a/wise-envoy-xds-core/src/main/java/com/transferwise/envoy/xds/DiscoveryServiceManager.java
+++ b/wise-envoy-xds-core/src/main/java/com/transferwise/envoy/xds/DiscoveryServiceManager.java
@@ -90,8 +90,8 @@ public class DiscoveryServiceManager<RequestT extends Message, StateUpdT> {
 
 
     public void init(StateUpdT initialStateChange, TypeUrl delayUpdatesUntilAckOf) {
-        init(initialStateChange);
         this.delayUpdatesUntilAckOf = delayUpdatesUntilAckOf;
+        init(initialStateChange, delayUpdatesUntilAckOf != null);
     }
 
     /**
@@ -99,7 +99,14 @@ public class DiscoveryServiceManager<RequestT extends Message, StateUpdT> {
      * All changes provided to pushUpdates are expected to apply sequentially from this initial state.
      */
     public void init(StateUpdT initialStateChange) {
-        discoveryServices.forEach((t, s) -> s.init(initialStateChange));
+        init(initialStateChange, false);
+    }
+
+    private void init(StateUpdT initialStateChange, boolean deferInitialResourceVersionRemovals) {
+        discoveryServices.forEach((t, s) -> {
+            s.init(initialStateChange);
+            s.setDeferInitialResourceVersionRemovals(deferInitialResourceVersionRemovals);
+        });
         initialized = true;
     }
 
@@ -122,7 +129,17 @@ public class DiscoveryServiceManager<RequestT extends Message, StateUpdT> {
         TypeUrl typeUrl = TypeUrl.of(value.getTypeUrl());
         DiscoveryService<RequestT, StateUpdT> discoveryService = discoveryServices.get(typeUrl);
         discoveryService.processUpdate(value);
+        updateOutstandingAckState(typeUrl, discoveryService);
 
+        if (currentChange != null) {
+            // Continue attempting to push the current change as this might have been an ack the current push was waiting for.
+            continuePush();
+        } else {
+            pushAllowedWorkIfAny();
+        }
+    }
+
+    private void updateOutstandingAckState(TypeUrl typeUrl, DiscoveryService<RequestT, StateUpdT> discoveryService) {
         if (discoveryService.awaitingAck()) {
             if (outstandingAcks.add(discoveryService)) {
                 metrics.onAwaitingAck();
@@ -135,17 +152,20 @@ public class DiscoveryServiceManager<RequestT extends Message, StateUpdT> {
                 }
             }
         }
-
-        if (currentChange != null) {
-            // Continue attempting to push the current change as this might have been an ack the current push was waiting for.
-            continuePush();
-        } else if (isPushAllowed()) {
-            pushWaitingChangeIfAny();
-        }
     }
 
     private boolean isPushAllowed() {
         return outstandingAcks.isEmpty() && delayUpdatesUntilAckOf == null;
+    }
+
+    private void pushAllowedWorkIfAny() {
+        if (!isPushAllowed()) {
+            return;
+        }
+        if (pushDeferredReconnectRemovalsIfAny()) {
+            return;
+        }
+        pushWaitingChangeIfAny();
     }
 
     private void beginPush() {
@@ -210,19 +230,40 @@ public class DiscoveryServiceManager<RequestT extends Message, StateUpdT> {
         // All done!
         currentChange = null;
 
-        pushWaitingChangeIfAny();
+        pushAllowedWorkIfAny();
     }
 
     /**
      * Start pushing any waiting changes to envoy.
      * Can only be called if there is no current change in progress.
      */
-    private void pushWaitingChangeIfAny() {
+    private boolean pushWaitingChangeIfAny() {
         Preconditions.checkState(currentChange == null, "Should not start pushing waiting change if we already have a current change to push.");
         currentChange = waitingStateBacklog.take();
         if (currentChange != null) {
             beginPush();
+            return true;
         }
+        return false;
+    }
+
+    private boolean pushDeferredReconnectRemovalsIfAny() {
+        Preconditions.checkState(currentChange == null, "Should not send deferred reconnect removals if we already have a current change to push.");
+        for (DiscoveryService<RequestT, StateUpdT> discoveryService: postOrder) {
+            if (discoveryService == null) {
+                continue;
+            }
+            if (discoveryService.hasDeferredReconnectRemovals()) {
+                discoveryService.sendDeferredReconnectRemovals();
+                if (discoveryService.awaitingAck()) {
+                    if (outstandingAcks.add(discoveryService)) {
+                        metrics.onAwaitingAck();
+                    }
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/wise-envoy-xds-core/src/main/java/com/transferwise/envoy/xds/delta/IncrementalDiscoveryService.java
+++ b/wise-envoy-xds-core/src/main/java/com/transferwise/envoy/xds/delta/IncrementalDiscoveryService.java
@@ -14,6 +14,7 @@ import io.envoyproxy.envoy.service.discovery.v3.Resource;
 import io.grpc.stub.StreamObserver;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -29,6 +30,10 @@ class IncrementalDiscoveryService<E extends Message, StateUpdT, DetailsT> extend
     private Long version = 0L;
 
     private final SubManager subManager;
+
+    private final HashSet<String> deferredReconnectRemovals = new HashSet<>();
+
+    private boolean deferInitialResourceVersionRemovals = false;
 
     IncrementalDiscoveryService(TypeUrl myTypeUrl, StreamObserver<DeltaDiscoveryResponse> responseObserver, IncrementalConfigBuilder<E, StateUpdT, DetailsT> configBuilder, NodeConfig<DetailsT> nodeConfig,
                                 SubManager subManager) {
@@ -75,12 +80,16 @@ class IncrementalDiscoveryService<E extends Message, StateUpdT, DetailsT> extend
         // If the resource doesn't exist, however, we will need to tell it to delete it.
         // We check against the filter because some values in resource name lists have special meaning to sub management (e.g. wildcards),
         // they're not actually resource names.
-        HashSet<String> removed = newSubs.stream().filter(filter).collect(Collectors.toCollection(HashSet::new));
+        HashSet<String> removed = newSubs.stream()
+            .filter(filter)
+            .filter(resourceName -> !initialState.contains(resourceName))
+            .collect(Collectors.toCollection(HashSet::new));
         // If envoy sent us an initial resource versions map it might also contain things that don't exist anymore.
-        // Again, we will need to tell envoy to delete it, but only if envoy has subscribed for updates about it.
+        // Again, we will need to tell envoy to delete it, but only if envoy has subscribed for updates about it. We defer
+        // these removals so DiscoveryServiceManager can send them in ADS remove order after dependent types have ACKed.
         // This is necessary because envoy doesn't explicitly subscribe to named resources (e.g. when it uses wildcards), so it can be
         // subscribed to things it has never explicitly asked us for.
-        initialState.stream().filter(filter).forEach(removed::add);
+        HashSet<String> reconnectRemovals = initialState.stream().filter(filter).collect(Collectors.toCollection(HashSet::new));
 
         // Now actually generate the resources for this sub update.
         IncrementalConfigBuilder.Resources<E> resources = getResources(filter);
@@ -88,8 +97,15 @@ class IncrementalDiscoveryService<E extends Message, StateUpdT, DetailsT> extend
         for (IncrementalConfigBuilder.NamedMessage<E> msg: resources.getResources()) {
             // If we generated a resource we don't want to tell envoy to remove it.
             removed.remove(msg.getName());
+            reconnectRemovals.remove(msg.getName());
+            deferredReconnectRemovals.remove(msg.getName());
         }
 
+        if (deferInitialResourceVersionRemovals) {
+            deferredReconnectRemovals.addAll(reconnectRemovals);
+        } else {
+            removed.addAll(reconnectRemovals);
+        }
         pushResources(resources.getResources(), removed);
     }
 
@@ -99,11 +115,43 @@ class IncrementalDiscoveryService<E extends Message, StateUpdT, DetailsT> extend
     }
 
     @Override
+    public void setDeferInitialResourceVersionRemovals(boolean deferInitialResourceVersionRemovals) {
+        this.deferInitialResourceVersionRemovals = deferInitialResourceVersionRemovals;
+    }
+
+    @Override
     public void pushNewState(IncrementalConfigBuilder.Response<E> response) {
         if (response.getAddAndUpdates().isEmpty() && response.getRemoves().isEmpty()) {
             return;
         }
         pushResources(response.getAddAndUpdates(), response.getRemoves());
+    }
+
+    @Override
+    public boolean hasDeferredReconnectRemovals() {
+        return !deferredReconnectRemovals.isEmpty();
+    }
+
+    @Override
+    public void sendDeferredReconnectRemovals() {
+        if (deferredReconnectRemovals.isEmpty()) {
+            return;
+        }
+
+        Predicate<String> currentlySubscribed = subFilter();
+        HashSet<String> removals = deferredReconnectRemovals.stream()
+            .filter(currentlySubscribed)
+            .collect(Collectors.toCollection(HashSet::new));
+
+        IncrementalConfigBuilder.Resources<E> currentResources = getResources(currentlySubscribed);
+        for (IncrementalConfigBuilder.NamedMessage<E> msg: currentResources.getResources()) {
+            removals.remove(msg.getName());
+        }
+
+        deferredReconnectRemovals.clear();
+        if (!removals.isEmpty()) {
+            pushResources(List.of(), removals);
+        }
     }
 
     private void pushResources(Collection<IncrementalConfigBuilder.NamedMessage<E>> resources, Collection<String> removals) {

--- a/wise-envoy-xds-core/src/test/java/com/transferwise/envoy/xds/DiscoveryServiceManagerTest.java
+++ b/wise-envoy-xds-core/src/test/java/com/transferwise/envoy/xds/DiscoveryServiceManagerTest.java
@@ -67,6 +67,7 @@ public class DiscoveryServiceManagerTest {
 
         InOrder inOrder = Mockito.inOrder(mockDiscoveryService);
         inOrder.verify(mockDiscoveryService).init(initUpdate);
+        inOrder.verify(mockDiscoveryService).setDeferInitialResourceVersionRemovals(false);
 
         var update = new DummyUpdate();
 
@@ -76,6 +77,7 @@ public class DiscoveryServiceManagerTest {
         inOrder.verify(mockDiscoveryService).awaitingAck();
         inOrder.verify(mockDiscoveryService).sendNetworkUpdatePost();
         inOrder.verify(mockDiscoveryService).awaitingAck();
+        inOrder.verify(mockDiscoveryService).hasDeferredReconnectRemovals();
         verifyNoMoreInteractions(mockDiscoveryService);
     }
 

--- a/wise-envoy-xds-core/src/test/java/com/transferwise/envoy/xds/DiscoveryServiceManagerTest.java
+++ b/wise-envoy-xds-core/src/test/java/com/transferwise/envoy/xds/DiscoveryServiceManagerTest.java
@@ -290,6 +290,36 @@ public class DiscoveryServiceManagerTest {
         inOrder.verify(mockDiscoveryServiceA).sendNetworkUpdatePost();
     }
 
+    @Test
+    public void testConfiguredDelayWithoutAckBlocksQueuedUpdates() {
+        final DiscoveryService<Message, DummyUpdate> mockDiscoveryServiceA = spy(StateAwareFakeDiscoveryService.class);
+        final DiscoveryService<Message, DummyUpdate> mockDiscoveryServiceB = spy(StateAwareFakeDiscoveryService.class);
+
+        DiscoveryServiceManager<Message, DummyUpdate> dsm = new DiscoveryServiceManager<>(
+            Map.of(TypeUrl.CDS, mockDiscoveryServiceA, TypeUrl.RDS, mockDiscoveryServiceB),
+            List.of(TypeUrl.CDS, TypeUrl.RDS), List.of(TypeUrl.RDS, TypeUrl.CDS),
+            new QueueBacklog(), DiscoveryServiceManagerMetrics.NOOP_METRICS
+        );
+
+        dsm.init(new DummyUpdate(), TypeUrl.RDS);
+
+        final var update = new DummyUpdate();
+        final var cdsRequest = CommonDiscoveryRequest.builder()
+            .typeUrl(TypeUrl.CDS.getTypeUrl())
+            .build();
+
+        dsm.processUpdate(cdsRequest);
+        dsm.processUpdate(cdsRequest);
+
+        dsm.pushUpdates(update);
+
+        dsm.processUpdate(cdsRequest);
+        dsm.processUpdate(cdsRequest);
+
+        verify(mockDiscoveryServiceA, never()).sendNetworkUpdatePre();
+        verify(mockDiscoveryServiceB, never()).sendNetworkUpdatePre();
+    }
+
     public static class StateAwareFakeDiscoveryService implements DiscoveryService<Message, DummyUpdate> {
 
         private boolean initialized = false;

--- a/wise-envoy-xds-core/src/test/java/com/transferwise/envoy/xds/delta/IncrementalDiscoveryServiceTest.java
+++ b/wise-envoy-xds-core/src/test/java/com/transferwise/envoy/xds/delta/IncrementalDiscoveryServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -25,6 +26,7 @@ import io.envoyproxy.envoy.service.discovery.v3.DeltaDiscoveryRequest;
 import io.envoyproxy.envoy.service.discovery.v3.DeltaDiscoveryResponse;
 import io.envoyproxy.envoy.service.discovery.v3.Resource;
 import io.grpc.stub.StreamObserver;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -367,10 +369,9 @@ public class IncrementalDiscoveryServiceTest {
         DeltaDiscoveryResponse resp = responseCaptor.getValue();
         assertThat(resp.getResourcesList()).hasSize(1).first().extracting(Resource::getName).isEqualTo("foo");
         assertThat(resp.getTypeUrl()).isEqualTo(TypeUrl.CDS.getTypeUrl());
-        // Since bar and baz came from initial_resource_versions, they are stale resources from the previous stream.
-        // They should not be removed in the immediate subscription response, because ADS has not yet replayed and ACKed
-        // dependent resource types such as RDS.
-        assertThat(resp.getRemovedResourcesList()).isEmpty();
+        // With no manager-level ACK barrier configured, stale resources from initial_resource_versions are removed
+        // in the initial subscription response.
+        assertThat(resp.getRemovedResourcesList()).containsExactlyInAnyOrder("bar", "baz");
 
         assertThat(ds.awaitingAck()).isTrue();
     }
@@ -412,10 +413,10 @@ public class IncrementalDiscoveryServiceTest {
         DeltaDiscoveryResponse resp = responseCaptor.getValue();
         assertThat(resp.getResourcesList()).hasSize(1).first().extracting(Resource::getName).isEqualTo("foo");
         assertThat(resp.getTypeUrl()).isEqualTo(TypeUrl.CDS.getTypeUrl());
-        // Envoy asked for bar, but also reported that it already knows bar in initial_resource_versions.
-        // That makes bar a stale resource from the previous stream, so its removal should be deferred.
+        // Envoy asked for bar, and reported that it already knows bar in initial_resource_versions.
+        // With no manager-level ACK barrier configured, that stale subscribed resource is removed immediately.
         // Baz exists in the initial versions, but the client has not asked to subscribe to it, so we don't remove it either.
-        assertThat(resp.getRemovedResourcesList()).isEmpty();
+        assertThat(resp.getRemovedResourcesList()).containsExactly("bar");
 
         assertThat(ds.awaitingAck()).isTrue();
     }
@@ -457,8 +458,8 @@ public class IncrementalDiscoveryServiceTest {
         );
         DiscoveryServiceManager<DeltaDiscoveryRequest, DummyUpdate> discoveryServiceManager = new DiscoveryServiceManager<>(
             Map.of(TypeUrl.CDS, cds, TypeUrl.RDS, rds),
-            TypeUrl.ADD_ORDER,
-            TypeUrl.REMOVE_ORDER,
+            List.of(TypeUrl.CDS, TypeUrl.RDS),
+            List.of(TypeUrl.RDS, TypeUrl.CDS),
             QueueingStateBacklog.<DummyUpdate>factory().build(),
             DiscoveryServiceManagerMetrics.NOOP_METRICS
         );
@@ -507,11 +508,404 @@ public class IncrementalDiscoveryServiceTest {
         assertThat(cdsDeferredRemovalResponse.getRemovedResourcesList()).containsExactly("cluster-a");
     }
 
+    @Test
+    public void testNoConfiguredDelaySendsInitialResourceVersionRemovalsInInitialResponse(@Mock StreamObserver<DeltaDiscoveryResponse> responseObserver,
+        @Mock IncrementalConfigBuilder<Cluster, DummyUpdate, Object> clusterConfigBuilder) {
+
+        final DummyUpdate initState = new DummyUpdate();
+        final NodeConfig<Object> nodeConfig = NodeConfig.builder()
+            .xdsConfig(XdsConfig.builder().clientDetails(new Object()).build())
+            .build();
+
+        when(clusterConfigBuilder.getResourcesRemoveOrder(eq(initState), any(), any()))
+            .thenReturn(IncrementalConfigBuilder.Resources.<Cluster>builder().build());
+
+        DiscoveryService<DeltaDiscoveryRequest, DummyUpdate> cds = new IncrementalDiscoveryService<>(
+            TypeUrl.CDS,
+            responseObserver,
+            clusterConfigBuilder,
+            nodeConfig,
+            new WildcardSubManager(nodeConfig)
+        );
+        DiscoveryServiceManager<DeltaDiscoveryRequest, DummyUpdate> discoveryServiceManager = new DiscoveryServiceManager<>(
+            Map.of(TypeUrl.CDS, cds),
+            List.of(TypeUrl.CDS),
+            List.of(TypeUrl.CDS),
+            QueueingStateBacklog.<DummyUpdate>factory().build(),
+            DiscoveryServiceManagerMetrics.NOOP_METRICS
+        );
+
+        discoveryServiceManager.init(initState);
+        InOrder inOrder = inOrder(responseObserver);
+
+        discoveryServiceManager.processUpdate(deltaRequest(TypeUrl.CDS, DeltaDiscoveryRequest.newBuilder()
+            .setTypeUrl(TypeUrl.CDS.getTypeUrl())
+            .addResourceNamesSubscribe("*")
+            .putInitialResourceVersions("cluster-a", "1")
+            .build()));
+
+        DeltaDiscoveryResponse reconnectResponse = nextResponse(inOrder, responseObserver);
+        assertThat(reconnectResponse.getTypeUrl()).isEqualTo(TypeUrl.CDS.getTypeUrl());
+        assertThat(reconnectResponse.getResourcesList()).isEmpty();
+        assertThat(reconnectResponse.getRemovedResourcesList()).containsExactly("cluster-a");
+        assertThat(cds.hasDeferredReconnectRemovals()).isFalse();
+
+        discoveryServiceManager.processUpdate(ackRequest(TypeUrl.CDS, reconnectResponse.getNonce()));
+        assertNoAdditionalResponsesSent(responseObserver, 1);
+    }
+
+    @Test
+    public void testEarlyConfiguredDelayCanSendRemovalsBeforeLaterSubscriptionsButStillProgresses(@Mock StreamObserver<DeltaDiscoveryResponse> responseObserver,
+        @Mock IncrementalConfigBuilder<Cluster, DummyUpdate, Object> clusterConfigBuilder,
+        @Mock IncrementalConfigBuilder<RouteConfiguration, DummyUpdate, Object> routeConfigBuilder) {
+
+        final DummyUpdate initState = new DummyUpdate();
+        final NodeConfig<Object> nodeConfig = NodeConfig.builder()
+            .xdsConfig(XdsConfig.builder().clientDetails(new Object()).build())
+            .build();
+
+        when(clusterConfigBuilder.getResourcesRemoveOrder(eq(initState), any(), any()))
+            .thenReturn(IncrementalConfigBuilder.Resources.<Cluster>builder().build());
+        when(routeConfigBuilder.getResourcesRemoveOrder(eq(initState), any(), any()))
+            .thenReturn(IncrementalConfigBuilder.Resources.<RouteConfiguration>builder().build());
+
+        DiscoveryService<DeltaDiscoveryRequest, DummyUpdate> cds = new IncrementalDiscoveryService<>(
+            TypeUrl.CDS,
+            responseObserver,
+            clusterConfigBuilder,
+            nodeConfig,
+            new WildcardSubManager(nodeConfig)
+        );
+        DiscoveryService<DeltaDiscoveryRequest, DummyUpdate> rds = new IncrementalDiscoveryService<>(
+            TypeUrl.RDS,
+            responseObserver,
+            routeConfigBuilder,
+            nodeConfig,
+            new SubListSubManager(nodeConfig)
+        );
+        DiscoveryServiceManager<DeltaDiscoveryRequest, DummyUpdate> discoveryServiceManager = new DiscoveryServiceManager<>(
+            Map.of(TypeUrl.CDS, cds, TypeUrl.RDS, rds),
+            List.of(TypeUrl.CDS, TypeUrl.RDS),
+            List.of(TypeUrl.RDS, TypeUrl.CDS),
+            QueueingStateBacklog.<DummyUpdate>factory().build(),
+            DiscoveryServiceManagerMetrics.NOOP_METRICS
+        );
+
+        discoveryServiceManager.init(initState, TypeUrl.CDS);
+        InOrder inOrder = inOrder(responseObserver);
+
+        discoveryServiceManager.processUpdate(deltaRequest(TypeUrl.CDS, DeltaDiscoveryRequest.newBuilder()
+            .setTypeUrl(TypeUrl.CDS.getTypeUrl())
+            .addResourceNamesSubscribe("*")
+            .putInitialResourceVersions("cluster-stale", "1")
+            .build()));
+        DeltaDiscoveryResponse cdsReconnectResponse = nextResponse(inOrder, responseObserver);
+        assertThat(cdsReconnectResponse.getTypeUrl()).isEqualTo(TypeUrl.CDS.getTypeUrl());
+        assertThat(cdsReconnectResponse.getRemovedResourcesList()).isEmpty();
+
+        discoveryServiceManager.processUpdate(ackRequest(TypeUrl.CDS, cdsReconnectResponse.getNonce()));
+
+        DeltaDiscoveryResponse cdsRemovalResponse = nextResponse(inOrder, responseObserver);
+        assertThat(cdsRemovalResponse.getTypeUrl()).isEqualTo(TypeUrl.CDS.getTypeUrl());
+        assertThat(cdsRemovalResponse.getRemovedResourcesList()).containsExactly("cluster-stale");
+
+        discoveryServiceManager.processUpdate(ackRequest(TypeUrl.CDS, cdsRemovalResponse.getNonce()));
+        assertNoAdditionalResponsesSent(responseObserver, 2);
+
+        discoveryServiceManager.processUpdate(deltaRequest(TypeUrl.RDS, DeltaDiscoveryRequest.newBuilder()
+            .setTypeUrl(TypeUrl.RDS.getTypeUrl())
+            .addResourceNamesSubscribe("route-stale")
+            .putInitialResourceVersions("route-stale", "1")
+            .build()));
+        DeltaDiscoveryResponse rdsReconnectResponse = nextResponse(inOrder, responseObserver);
+        assertThat(rdsReconnectResponse.getTypeUrl()).isEqualTo(TypeUrl.RDS.getTypeUrl());
+        assertThat(rdsReconnectResponse.getRemovedResourcesList()).isEmpty();
+
+        discoveryServiceManager.processUpdate(ackRequest(TypeUrl.RDS, rdsReconnectResponse.getNonce()));
+
+        DeltaDiscoveryResponse rdsRemovalResponse = nextResponse(inOrder, responseObserver);
+        assertThat(rdsRemovalResponse.getTypeUrl()).isEqualTo(TypeUrl.RDS.getTypeUrl());
+        assertThat(rdsRemovalResponse.getRemovedResourcesList()).containsExactly("route-stale");
+    }
+
+    @Test
+    public void testReconnectNetworkUpdatesWaitForDeferredInitialRemovals(@Mock StreamObserver<DeltaDiscoveryResponse> responseObserver,
+        @Mock IncrementalConfigBuilder<Cluster, DummyUpdate, Object> clusterConfigBuilder,
+        @Mock IncrementalConfigBuilder<RouteConfiguration, DummyUpdate, Object> routeConfigBuilder) {
+
+        final DummyUpdate initState = new DummyUpdate();
+        final DummyUpdate nextState = new DummyUpdate();
+        final NodeConfig<Object> nodeConfig = NodeConfig.builder()
+            .xdsConfig(XdsConfig.builder().clientDetails(new Object()).build())
+            .build();
+
+        final RouteConfiguration routeWithoutDeletedCluster = RouteConfiguration.newBuilder()
+            .setName("route-x")
+            .build();
+        final Cluster newCluster = Cluster.newBuilder()
+            .setName("cluster-b")
+            .build();
+
+        when(clusterConfigBuilder.getResourcesRemoveOrder(eq(initState), any(), any()))
+            .thenReturn(IncrementalConfigBuilder.Resources.<Cluster>builder().build());
+        when(routeConfigBuilder.getResourcesRemoveOrder(eq(initState), any(), any()))
+            .thenReturn(IncrementalConfigBuilder.Resources.<RouteConfiguration>builder()
+                .resource(IncrementalConfigBuilder.NamedMessage.of(routeWithoutDeletedCluster))
+                .build());
+        when(clusterConfigBuilder.addOrder(eq(nextState), any(), any()))
+            .thenReturn(IncrementalConfigBuilder.Response.<Cluster>builder()
+                .addAndUpdate(IncrementalConfigBuilder.NamedMessage.of(newCluster))
+                .build());
+
+        DiscoveryService<DeltaDiscoveryRequest, DummyUpdate> cds = new IncrementalDiscoveryService<>(
+            TypeUrl.CDS,
+            responseObserver,
+            clusterConfigBuilder,
+            nodeConfig,
+            new WildcardSubManager(nodeConfig)
+        );
+        DiscoveryService<DeltaDiscoveryRequest, DummyUpdate> rds = new IncrementalDiscoveryService<>(
+            TypeUrl.RDS,
+            responseObserver,
+            routeConfigBuilder,
+            nodeConfig,
+            new SubListSubManager(nodeConfig)
+        );
+        DiscoveryServiceManager<DeltaDiscoveryRequest, DummyUpdate> discoveryServiceManager = new DiscoveryServiceManager<>(
+            Map.of(TypeUrl.CDS, cds, TypeUrl.RDS, rds),
+            List.of(TypeUrl.CDS, TypeUrl.RDS),
+            List.of(TypeUrl.RDS, TypeUrl.CDS),
+            QueueingStateBacklog.<DummyUpdate>factory().build(),
+            DiscoveryServiceManagerMetrics.NOOP_METRICS
+        );
+
+        discoveryServiceManager.init(initState, TypeUrl.RDS);
+        InOrder inOrder = inOrder(responseObserver);
+
+        discoveryServiceManager.processUpdate(deltaRequest(TypeUrl.CDS, DeltaDiscoveryRequest.newBuilder()
+            .setTypeUrl(TypeUrl.CDS.getTypeUrl())
+            .addResourceNamesSubscribe("*")
+            .putInitialResourceVersions("cluster-a", "1")
+            .build()));
+        DeltaDiscoveryResponse cdsReconnectResponse = nextResponse(inOrder, responseObserver);
+        assertThat(cdsReconnectResponse.getRemovedResourcesList()).isEmpty();
+
+        discoveryServiceManager.processUpdate(ackRequest(TypeUrl.CDS, cdsReconnectResponse.getNonce()));
+
+        discoveryServiceManager.processUpdate(deltaRequest(TypeUrl.RDS, DeltaDiscoveryRequest.newBuilder()
+            .setTypeUrl(TypeUrl.RDS.getTypeUrl())
+            .addResourceNamesSubscribe("route-x")
+            .putInitialResourceVersions("route-x", "1")
+            .build()));
+        DeltaDiscoveryResponse rdsReconnectResponse = nextResponse(inOrder, responseObserver);
+        assertThat(rdsReconnectResponse.getTypeUrl()).isEqualTo(TypeUrl.RDS.getTypeUrl());
+        assertThat(rdsReconnectResponse.getResourcesList()).hasSize(1).first().extracting(Resource::getName).isEqualTo("route-x");
+        assertThat(rdsReconnectResponse.getRemovedResourcesList()).isEmpty();
+
+        discoveryServiceManager.pushUpdates(nextState);
+        verify(responseObserver, times(2)).onNext(any());
+
+        discoveryServiceManager.processUpdate(ackRequest(TypeUrl.RDS, rdsReconnectResponse.getNonce()));
+
+        DeltaDiscoveryResponse cdsDeferredRemovalResponse = nextResponse(inOrder, responseObserver);
+        assertThat(cdsDeferredRemovalResponse.getTypeUrl()).isEqualTo(TypeUrl.CDS.getTypeUrl());
+        assertThat(cdsDeferredRemovalResponse.getResourcesList()).isEmpty();
+        assertThat(cdsDeferredRemovalResponse.getRemovedResourcesList()).containsExactly("cluster-a");
+
+        discoveryServiceManager.processUpdate(ackRequest(TypeUrl.CDS, cdsDeferredRemovalResponse.getNonce()));
+
+        DeltaDiscoveryResponse cdsNetworkUpdateResponse = nextResponse(inOrder, responseObserver);
+        assertThat(cdsNetworkUpdateResponse.getTypeUrl()).isEqualTo(TypeUrl.CDS.getTypeUrl());
+        assertThat(cdsNetworkUpdateResponse.getResourcesList()).hasSize(1).first().extracting(Resource::getName).isEqualTo("cluster-b");
+        assertThat(cdsNetworkUpdateResponse.getRemovedResourcesList()).isEmpty();
+    }
+
+    @Test
+    public void testDeferredReconnectRemovalsUseRemoveOrderAndWaitForAck(@Mock StreamObserver<DeltaDiscoveryResponse> responseObserver,
+        @Mock IncrementalConfigBuilder<Cluster, DummyUpdate, Object> clusterConfigBuilder,
+        @Mock IncrementalConfigBuilder<ClusterLoadAssignment, DummyUpdate, Object> endpointConfigBuilder,
+        @Mock IncrementalConfigBuilder<RouteConfiguration, DummyUpdate, Object> routeConfigBuilder) {
+
+        final DummyUpdate initState = new DummyUpdate();
+        final NodeConfig<Object> nodeConfig = NodeConfig.builder()
+            .xdsConfig(XdsConfig.builder().clientDetails(new Object()).build())
+            .build();
+
+        final RouteConfiguration currentRoute = RouteConfiguration.newBuilder()
+            .setName("route-current")
+            .build();
+
+        when(routeConfigBuilder.getResourcesRemoveOrder(eq(initState), any(), any()))
+            .thenReturn(IncrementalConfigBuilder.Resources.<RouteConfiguration>builder()
+                .resource(IncrementalConfigBuilder.NamedMessage.of(currentRoute))
+                .build());
+        when(clusterConfigBuilder.getResourcesRemoveOrder(eq(initState), any(), any()))
+            .thenReturn(IncrementalConfigBuilder.Resources.<Cluster>builder().build());
+        when(endpointConfigBuilder.getResourcesRemoveOrder(eq(initState), any(), any()))
+            .thenReturn(IncrementalConfigBuilder.Resources.<ClusterLoadAssignment>builder().build());
+
+        DiscoveryService<DeltaDiscoveryRequest, DummyUpdate> cds = new IncrementalDiscoveryService<>(
+            TypeUrl.CDS,
+            responseObserver,
+            clusterConfigBuilder,
+            nodeConfig,
+            new WildcardSubManager(nodeConfig)
+        );
+        DiscoveryService<DeltaDiscoveryRequest, DummyUpdate> eds = new IncrementalDiscoveryService<>(
+            TypeUrl.EDS,
+            responseObserver,
+            endpointConfigBuilder,
+            nodeConfig,
+            new SubListSubManager(nodeConfig)
+        );
+        DiscoveryService<DeltaDiscoveryRequest, DummyUpdate> rds = new IncrementalDiscoveryService<>(
+            TypeUrl.RDS,
+            responseObserver,
+            routeConfigBuilder,
+            nodeConfig,
+            new SubListSubManager(nodeConfig)
+        );
+        DiscoveryServiceManager<DeltaDiscoveryRequest, DummyUpdate> discoveryServiceManager = new DiscoveryServiceManager<>(
+            Map.of(TypeUrl.CDS, cds, TypeUrl.EDS, eds, TypeUrl.RDS, rds),
+            List.of(TypeUrl.CDS, TypeUrl.EDS, TypeUrl.RDS),
+            List.of(TypeUrl.RDS, TypeUrl.CDS, TypeUrl.EDS),
+            QueueingStateBacklog.<DummyUpdate>factory().build(),
+            DiscoveryServiceManagerMetrics.NOOP_METRICS
+        );
+
+        discoveryServiceManager.init(initState, TypeUrl.RDS);
+        InOrder inOrder = inOrder(responseObserver);
+
+        discoveryServiceManager.processUpdate(deltaRequest(TypeUrl.CDS, DeltaDiscoveryRequest.newBuilder()
+            .setTypeUrl(TypeUrl.CDS.getTypeUrl())
+            .addResourceNamesSubscribe("*")
+            .putInitialResourceVersions("cluster-stale", "1")
+            .build()));
+        DeltaDiscoveryResponse cdsReconnectResponse = nextResponse(inOrder, responseObserver);
+        assertThat(cdsReconnectResponse.getTypeUrl()).isEqualTo(TypeUrl.CDS.getTypeUrl());
+        assertThat(cdsReconnectResponse.getResourcesList()).isEmpty();
+        assertThat(cdsReconnectResponse.getRemovedResourcesList()).isEmpty();
+        discoveryServiceManager.processUpdate(ackRequest(TypeUrl.CDS, cdsReconnectResponse.getNonce()));
+
+        discoveryServiceManager.processUpdate(deltaRequest(TypeUrl.EDS, DeltaDiscoveryRequest.newBuilder()
+            .setTypeUrl(TypeUrl.EDS.getTypeUrl())
+            .addResourceNamesSubscribe("endpoint-stale")
+            .putInitialResourceVersions("endpoint-stale", "1")
+            .build()));
+        DeltaDiscoveryResponse edsReconnectResponse = nextResponse(inOrder, responseObserver);
+        assertThat(edsReconnectResponse.getTypeUrl()).isEqualTo(TypeUrl.EDS.getTypeUrl());
+        assertThat(edsReconnectResponse.getResourcesList()).isEmpty();
+        assertThat(edsReconnectResponse.getRemovedResourcesList()).isEmpty();
+        discoveryServiceManager.processUpdate(ackRequest(TypeUrl.EDS, edsReconnectResponse.getNonce()));
+
+        discoveryServiceManager.processUpdate(deltaRequest(TypeUrl.RDS, DeltaDiscoveryRequest.newBuilder()
+            .setTypeUrl(TypeUrl.RDS.getTypeUrl())
+            .addResourceNamesSubscribe("route-current")
+            .addResourceNamesSubscribe("route-stale")
+            .putInitialResourceVersions("route-stale", "1")
+            .build()));
+        DeltaDiscoveryResponse rdsReconnectResponse = nextResponse(inOrder, responseObserver);
+        assertThat(rdsReconnectResponse.getTypeUrl()).isEqualTo(TypeUrl.RDS.getTypeUrl());
+        assertThat(rdsReconnectResponse.getResourcesList()).hasSize(1).first().extracting(Resource::getName).isEqualTo("route-current");
+        assertThat(rdsReconnectResponse.getRemovedResourcesList()).isEmpty();
+
+        discoveryServiceManager.processUpdate(ackRequest(TypeUrl.RDS, rdsReconnectResponse.getNonce()));
+
+        DeltaDiscoveryResponse rdsRemovalResponse = nextResponse(inOrder, responseObserver);
+        assertThat(rdsRemovalResponse.getTypeUrl()).isEqualTo(TypeUrl.RDS.getTypeUrl());
+        assertThat(rdsRemovalResponse.getResourcesList()).isEmpty();
+        assertThat(rdsRemovalResponse.getRemovedResourcesList()).containsExactly("route-stale");
+        assertNoAdditionalResponsesSent(responseObserver, 4);
+
+        discoveryServiceManager.processUpdate(nonAckRequest(TypeUrl.RDS));
+        assertNoAdditionalResponsesSent(responseObserver, 4);
+
+        discoveryServiceManager.processUpdate(ackRequest(TypeUrl.RDS, rdsRemovalResponse.getNonce()));
+
+        DeltaDiscoveryResponse cdsRemovalResponse = nextResponse(inOrder, responseObserver);
+        assertThat(cdsRemovalResponse.getTypeUrl()).isEqualTo(TypeUrl.CDS.getTypeUrl());
+        assertThat(cdsRemovalResponse.getResourcesList()).isEmpty();
+        assertThat(cdsRemovalResponse.getRemovedResourcesList()).containsExactly("cluster-stale");
+        assertNoAdditionalResponsesSent(responseObserver, 5);
+
+        discoveryServiceManager.processUpdate(nonAckRequest(TypeUrl.CDS));
+        assertNoAdditionalResponsesSent(responseObserver, 5);
+
+        discoveryServiceManager.processUpdate(ackRequest(TypeUrl.CDS, cdsRemovalResponse.getNonce()));
+
+        DeltaDiscoveryResponse edsRemovalResponse = nextResponse(inOrder, responseObserver);
+        assertThat(edsRemovalResponse.getTypeUrl()).isEqualTo(TypeUrl.EDS.getTypeUrl());
+        assertThat(edsRemovalResponse.getResourcesList()).isEmpty();
+        assertThat(edsRemovalResponse.getRemovedResourcesList()).containsExactly("endpoint-stale");
+    }
+
+    @Test
+    public void testDoesNotDeferInitialStateRemovalForUnsubscribedSubListResource(@Mock StreamObserver<DeltaDiscoveryResponse> responseObserver,
+        @Mock IncrementalConfigBuilder<ClusterLoadAssignment, DummyUpdate, Object> configBuilder) {
+
+        final DummyUpdate initState = new DummyUpdate();
+        final NodeConfig<Object> nodeConfig = NodeConfig.builder()
+            .xdsConfig(XdsConfig.builder().clientDetails(new Object()).build())
+            .build();
+        final ClusterLoadAssignment currentEndpoint = ClusterLoadAssignment.newBuilder()
+            .setClusterName("endpoint-current")
+            .build();
+
+        when(configBuilder.getResourcesRemoveOrder(eq(initState), any(), any()))
+            .thenReturn(IncrementalConfigBuilder.Resources.<ClusterLoadAssignment>builder()
+                .resource(IncrementalConfigBuilder.NamedMessage.of(currentEndpoint))
+                .build());
+
+        DiscoveryService<DeltaDiscoveryRequest, DummyUpdate> ds = new IncrementalDiscoveryService<>(
+            TypeUrl.EDS,
+            responseObserver,
+            configBuilder,
+            nodeConfig,
+            new SubListSubManager(nodeConfig)
+        );
+
+        ds.init(initState);
+        ds.processUpdate(deltaRequest(TypeUrl.EDS, DeltaDiscoveryRequest.newBuilder()
+            .setTypeUrl(TypeUrl.EDS.getTypeUrl())
+            .addResourceNamesSubscribe("endpoint-current")
+            .putInitialResourceVersions("endpoint-unsubscribed", "1")
+            .build()));
+
+        verify(responseObserver).onNext(responseCaptor.capture());
+        DeltaDiscoveryResponse resp = responseCaptor.getValue();
+        assertThat(resp.getTypeUrl()).isEqualTo(TypeUrl.EDS.getTypeUrl());
+        assertThat(resp.getResourcesList()).hasSize(1).first().extracting(Resource::getName).isEqualTo("endpoint-current");
+        assertThat(resp.getRemovedResourcesList()).isEmpty();
+        assertThat(ds.hasDeferredReconnectRemovals()).isFalse();
+    }
+
     private CommonDiscoveryRequest<DeltaDiscoveryRequest> deltaRequest(TypeUrl typeUrl, DeltaDiscoveryRequest request) {
         return CommonDiscoveryRequest.<DeltaDiscoveryRequest>builder()
             .typeUrl(typeUrl.getTypeUrl())
             .message(request)
             .build();
+    }
+
+    private CommonDiscoveryRequest<DeltaDiscoveryRequest> ackRequest(TypeUrl typeUrl, String nonce) {
+        return deltaRequest(typeUrl, DeltaDiscoveryRequest.newBuilder()
+            .setTypeUrl(typeUrl.getTypeUrl())
+            .setResponseNonce(nonce)
+            .build());
+    }
+
+    private CommonDiscoveryRequest<DeltaDiscoveryRequest> nonAckRequest(TypeUrl typeUrl) {
+        return deltaRequest(typeUrl, DeltaDiscoveryRequest.newBuilder()
+            .setTypeUrl(typeUrl.getTypeUrl())
+            .build());
+    }
+
+    private void assertNoAdditionalResponsesSent(StreamObserver<DeltaDiscoveryResponse> responseObserver, int expectedResponsesSoFar) {
+        verify(responseObserver, times(expectedResponsesSoFar)).onNext(any());
+    }
+
+    private DeltaDiscoveryResponse nextResponse(InOrder inOrder, StreamObserver<DeltaDiscoveryResponse> responseObserver) {
+        inOrder.verify(responseObserver).onNext(responseCaptor.capture());
+        return responseCaptor.getValue();
     }
 
 }

--- a/wise-envoy-xds-core/src/test/java/com/transferwise/envoy/xds/delta/IncrementalDiscoveryServiceTest.java
+++ b/wise-envoy-xds-core/src/test/java/com/transferwise/envoy/xds/delta/IncrementalDiscoveryServiceTest.java
@@ -11,16 +11,21 @@ import static org.mockito.Mockito.when;
 
 import com.transferwise.envoy.xds.CommonDiscoveryRequest;
 import com.transferwise.envoy.xds.DiscoveryService;
+import com.transferwise.envoy.xds.DiscoveryServiceManager;
 import com.transferwise.envoy.xds.NodeConfig;
 import com.transferwise.envoy.xds.TypeUrl;
 import com.transferwise.envoy.xds.XdsConfig;
+import com.transferwise.envoy.xds.api.DiscoveryServiceManagerMetrics;
 import com.transferwise.envoy.xds.api.IncrementalConfigBuilder;
+import com.transferwise.envoy.xds.api.utils.QueueingStateBacklog;
 import io.envoyproxy.envoy.config.cluster.v3.Cluster;
 import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
+import io.envoyproxy.envoy.config.route.v3.RouteConfiguration;
 import io.envoyproxy.envoy.service.discovery.v3.DeltaDiscoveryRequest;
 import io.envoyproxy.envoy.service.discovery.v3.DeltaDiscoveryResponse;
 import io.envoyproxy.envoy.service.discovery.v3.Resource;
 import io.grpc.stub.StreamObserver;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -362,9 +367,10 @@ public class IncrementalDiscoveryServiceTest {
         DeltaDiscoveryResponse resp = responseCaptor.getValue();
         assertThat(resp.getResourcesList()).hasSize(1).first().extracting(Resource::getName).isEqualTo("foo");
         assertThat(resp.getTypeUrl()).isEqualTo(TypeUrl.CDS.getTypeUrl());
-        // Since bar and baz don't exist, they must have been removed since this client last got a state update (before it lost connection to the ADS.)
-        // Tell it to delete them.
-        assertThat(resp.getRemovedResourcesList()).containsExactlyInAnyOrder("bar", "baz");
+        // Since bar and baz came from initial_resource_versions, they are stale resources from the previous stream.
+        // They should not be removed in the immediate subscription response, because ADS has not yet replayed and ACKed
+        // dependent resource types such as RDS.
+        assertThat(resp.getRemovedResourcesList()).isEmpty();
 
         assertThat(ds.awaitingAck()).isTrue();
     }
@@ -406,10 +412,106 @@ public class IncrementalDiscoveryServiceTest {
         DeltaDiscoveryResponse resp = responseCaptor.getValue();
         assertThat(resp.getResourcesList()).hasSize(1).first().extracting(Resource::getName).isEqualTo("foo");
         assertThat(resp.getTypeUrl()).isEqualTo(TypeUrl.CDS.getTypeUrl());
-        // Envoy asked for bar, but it doesn't exist. While baz exists in the initial versions, the client has not asked to subscribe to it, so we don't send a remove.
-        assertThat(resp.getRemovedResourcesList()).containsOnly("bar");
+        // Envoy asked for bar, but also reported that it already knows bar in initial_resource_versions.
+        // That makes bar a stale resource from the previous stream, so its removal should be deferred.
+        // Baz exists in the initial versions, but the client has not asked to subscribe to it, so we don't remove it either.
+        assertThat(resp.getRemovedResourcesList()).isEmpty();
 
         assertThat(ds.awaitingAck()).isTrue();
+    }
+
+    @Test
+    public void testReconnectInitialResourceVersionRemovalsWaitForConfiguredAck(@Mock StreamObserver<DeltaDiscoveryResponse> responseObserver,
+        @Mock IncrementalConfigBuilder<Cluster, DummyUpdate, Object> clusterConfigBuilder,
+        @Mock IncrementalConfigBuilder<RouteConfiguration, DummyUpdate, Object> routeConfigBuilder) {
+
+        final DummyUpdate initState = new DummyUpdate();
+        final NodeConfig<Object> nodeConfig = NodeConfig.builder()
+            .xdsConfig(XdsConfig.builder().clientDetails(new Object()).build())
+            .build();
+
+        final RouteConfiguration routeWithoutDeletedCluster = RouteConfiguration.newBuilder()
+            .setName("route-x")
+            .build();
+
+        when(clusterConfigBuilder.getResourcesRemoveOrder(eq(initState), any(), any()))
+            .thenReturn(IncrementalConfigBuilder.Resources.<Cluster>builder().build());
+        when(routeConfigBuilder.getResourcesRemoveOrder(eq(initState), any(), any()))
+            .thenReturn(IncrementalConfigBuilder.Resources.<RouteConfiguration>builder()
+                .resource(IncrementalConfigBuilder.NamedMessage.of(routeWithoutDeletedCluster))
+                .build());
+
+        DiscoveryService<DeltaDiscoveryRequest, DummyUpdate> cds = new IncrementalDiscoveryService<>(
+            TypeUrl.CDS,
+            responseObserver,
+            clusterConfigBuilder,
+            nodeConfig,
+            new WildcardSubManager(nodeConfig)
+        );
+        DiscoveryService<DeltaDiscoveryRequest, DummyUpdate> rds = new IncrementalDiscoveryService<>(
+            TypeUrl.RDS,
+            responseObserver,
+            routeConfigBuilder,
+            nodeConfig,
+            new SubListSubManager(nodeConfig)
+        );
+        DiscoveryServiceManager<DeltaDiscoveryRequest, DummyUpdate> discoveryServiceManager = new DiscoveryServiceManager<>(
+            Map.of(TypeUrl.CDS, cds, TypeUrl.RDS, rds),
+            TypeUrl.ADD_ORDER,
+            TypeUrl.REMOVE_ORDER,
+            QueueingStateBacklog.<DummyUpdate>factory().build(),
+            DiscoveryServiceManagerMetrics.NOOP_METRICS
+        );
+
+        discoveryServiceManager.init(initState, TypeUrl.RDS);
+        InOrder inOrder = inOrder(responseObserver);
+
+        discoveryServiceManager.processUpdate(deltaRequest(TypeUrl.CDS, DeltaDiscoveryRequest.newBuilder()
+            .setTypeUrl(TypeUrl.CDS.getTypeUrl())
+            .addResourceNamesSubscribe("*")
+            .putInitialResourceVersions("cluster-a", "1")
+            .build()));
+
+        inOrder.verify(responseObserver).onNext(responseCaptor.capture());
+        DeltaDiscoveryResponse cdsReconnectResponse = responseCaptor.getValue();
+        assertThat(cdsReconnectResponse.getTypeUrl()).isEqualTo(TypeUrl.CDS.getTypeUrl());
+        assertThat(cdsReconnectResponse.getResourcesList()).isEmpty();
+        assertThat(cdsReconnectResponse.getRemovedResourcesList()).isEmpty();
+
+        discoveryServiceManager.processUpdate(deltaRequest(TypeUrl.CDS, DeltaDiscoveryRequest.newBuilder()
+            .setTypeUrl(TypeUrl.CDS.getTypeUrl())
+            .setResponseNonce(cdsReconnectResponse.getNonce())
+            .build()));
+
+        discoveryServiceManager.processUpdate(deltaRequest(TypeUrl.RDS, DeltaDiscoveryRequest.newBuilder()
+            .setTypeUrl(TypeUrl.RDS.getTypeUrl())
+            .addResourceNamesSubscribe("route-x")
+            .putInitialResourceVersions("route-x", "1")
+            .build()));
+
+        inOrder.verify(responseObserver).onNext(responseCaptor.capture());
+        DeltaDiscoveryResponse rdsReconnectResponse = responseCaptor.getValue();
+        assertThat(rdsReconnectResponse.getTypeUrl()).isEqualTo(TypeUrl.RDS.getTypeUrl());
+        assertThat(rdsReconnectResponse.getResourcesList()).hasSize(1).first().extracting(Resource::getName).isEqualTo("route-x");
+        assertThat(rdsReconnectResponse.getRemovedResourcesList()).isEmpty();
+
+        discoveryServiceManager.processUpdate(deltaRequest(TypeUrl.RDS, DeltaDiscoveryRequest.newBuilder()
+            .setTypeUrl(TypeUrl.RDS.getTypeUrl())
+            .setResponseNonce(rdsReconnectResponse.getNonce())
+            .build()));
+
+        inOrder.verify(responseObserver).onNext(responseCaptor.capture());
+        DeltaDiscoveryResponse cdsDeferredRemovalResponse = responseCaptor.getValue();
+        assertThat(cdsDeferredRemovalResponse.getTypeUrl()).isEqualTo(TypeUrl.CDS.getTypeUrl());
+        assertThat(cdsDeferredRemovalResponse.getResourcesList()).isEmpty();
+        assertThat(cdsDeferredRemovalResponse.getRemovedResourcesList()).containsExactly("cluster-a");
+    }
+
+    private CommonDiscoveryRequest<DeltaDiscoveryRequest> deltaRequest(TypeUrl typeUrl, DeltaDiscoveryRequest request) {
+        return CommonDiscoveryRequest.<DeltaDiscoveryRequest>builder()
+            .typeUrl(typeUrl.getTypeUrl())
+            .message(request)
+            .build();
     }
 
 }

--- a/wise-envoy-xds-e2e-tests/build.gradle
+++ b/wise-envoy-xds-e2e-tests/build.gradle
@@ -19,11 +19,11 @@ dependencies {
     implementation project(':wise-envoy-xds-example')
     implementation 'com.transferwise.envoy:envoy-api:1.17.0'
     implementation 'org.projectlombok:lombok:1.18.26'
-    implementation 'org.testcontainers:junit-jupiter:1.17.6'
+    implementation 'org.testcontainers:testcontainers-junit-jupiter:2.0.5'
     implementation('org.assertj:assertj-core:3.24.2')
     compileOnly 'org.projectlombok:lombok:1.18.26'
     annotationProcessor 'org.projectlombok:lombok:1.18.26'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.26'
-    testImplementation 'org.testcontainers:testcontainers:1.17.6'
+    testImplementation 'org.testcontainers:testcontainers:2.0.5'
     testImplementation 'org.awaitility:awaitility:4.2.0'
 }

--- a/wise-envoy-xds-e2e-tests/src/test/java/com/transferwise/envoy/e2e/BaseEnvoyIntTest.java
+++ b/wise-envoy-xds-e2e-tests/src/test/java/com/transferwise/envoy/e2e/BaseEnvoyIntTest.java
@@ -17,6 +17,7 @@ import com.transferwise.envoy.e2e.utils.EnvoyContainer;
 import com.transferwise.envoy.e2e.utils.GrpcXdsV3ProtocolLoggingInterceptor;
 import com.transferwise.envoy.xds.AggregatedDiscoveryService;
 import com.transferwise.envoy.xds.TypeUrl;
+import com.transferwise.envoy.xds.XdsConfig;
 import com.transferwise.envoy.xds.api.utils.MergingStateBacklog;
 import com.transferwise.envoy.example.ClusterManager;
 import com.transferwise.envoy.example.config.ClientConfig;
@@ -85,6 +86,11 @@ public abstract class BaseEnvoyIntTest<AsserterT extends EnvoyAssert<AsserterT>>
     protected abstract AsserterT envoyAssertThat(Conversation conversation);
 
     protected AggregatedDiscoveryService<SimpleUpdate, ClientConfig> configureAds(ClusterManager clusterManager, List<DiscoveryServiceManagerEventListener> conversations) {
+        return configureAds(clusterManager, conversations, null);
+    }
+
+    protected AggregatedDiscoveryService<SimpleUpdate, ClientConfig> configureAds(ClusterManager clusterManager, List<DiscoveryServiceManagerEventListener> conversations, TypeUrl delayUpdatesUntilAckOf) {
+        StaticClientConfigSource staticClientConfigSource = new StaticClientConfigSource();
         return new AggregatedDiscoveryService<>(
             clusterManager, // Cluster managers track the network state and tell us when it changes
             ImmutableList.of(// ConfigBuilders generate envoy configuration (xDS messages) based on network state changes and the client config
@@ -92,7 +98,14 @@ public abstract class BaseEnvoyIntTest<AsserterT extends EnvoyAssert<AsserterT>>
                 new ClusterLoadAssignmentConfigBuilder(),
                 new RouteConfigurationConfigBuilder()
             ),
-            new StaticClientConfigSource(), // ClientConfigProviders provide per-client configuration to the config builders
+            node -> {
+                XdsConfig<ClientConfig> staticConfig = staticClientConfigSource.lookup(node);
+                return XdsConfig.<ClientConfig>builder()
+                    .clientDetails(staticConfig.getClientDetails())
+                    .delayUpdatesUntilAckOf(delayUpdatesUntilAckOf)
+                    .silentNacks(staticConfig.isSilentNacks())
+                    .build();
+            }, // ClientConfigProviders provide per-client configuration to the config builders
             ImmutableList.of(), // Our example has no event listeners, but you can use these for things like tracking connected clients
             MergingStateBacklog.factory(), // Strategy for handling a backlog of network state updates.
             () -> {
@@ -101,6 +114,48 @@ public abstract class BaseEnvoyIntTest<AsserterT extends EnvoyAssert<AsserterT>>
                 return listener;
             }
         );
+    }
+
+    protected Conversation reconnectAfterRemovingBar(TypeUrl delayUpdatesUntilAckOf) throws IOException, InterruptedException {
+        ClusterManager clusterManager = new ClusterManager();
+
+        List<DiscoveryServiceManagerEventListener> conversations = Collections.synchronizedList(new ArrayList<>());
+
+        AggregatedDiscoveryService<SimpleUpdate, ClientConfig> ads = configureAds(clusterManager, conversations, delayUpdatesUntilAckOf);
+
+        ConversationLogger conversationInterceptor = new ConversationLogger();
+        server = ServerBuilder.forPort(6566).addService(ads).intercept(conversationInterceptor).intercept(new GrpcXdsV3ProtocolLoggingInterceptor()).build();
+        server.start();
+        org.testcontainers.Testcontainers.exposeHostPorts(6566);
+
+        await().atMost(30, TimeUnit.SECONDS)
+            .untilAsserted(() -> assertThat(conversationInterceptor.getConversations()).isNotEmpty().first(assertFactory()).hadConversationsWith(TypeUrl.CDS.getTypeUrl(), TypeUrl.RDS.getTypeUrl()));
+        await().atMost(30, TimeUnit.SECONDS).until(() -> conversations.size() > 0 && conversations.get(0).isIdle());
+
+        clusterManager.setEndpoints(ImmutableMap.of(
+            "foo", ImmutableList.of(HostAndPort.fromString("127.0.0.5"), HostAndPort.fromString("127.0.0.6")),
+            "bar", ImmutableList.of(HostAndPort.fromString("127.0.0.7"), HostAndPort.fromString("127.0.0.8"))
+        ));
+
+        await().atMost(30, TimeUnit.SECONDS).until(() -> conversations.get(0).getPushed() > 0 && conversations.get(0).isIdle());
+
+        TypedEnvoyConfigDump dump = adminClient.configDump();
+        assertThat(getClusters(dump)).extracting(Cluster::getName).containsExactlyInAnyOrder("foo", "bar");
+
+        server.shutdownNow();
+        server.awaitTermination();
+
+        clusterManager.removeService("bar");
+
+        server = ServerBuilder.forPort(6566).addService(ads).intercept(conversationInterceptor).intercept(new GrpcXdsV3ProtocolLoggingInterceptor()).build();
+        server.start();
+        org.testcontainers.Testcontainers.exposeHostPorts(6566);
+
+        await().atMost(30, TimeUnit.SECONDS)
+            .untilAsserted(() -> assertThat(conversationInterceptor.getConversations()).hasSize(2).last(assertFactory()).hadConversationsWith(TypeUrl.CDS.getTypeUrl(), TypeUrl.RDS.getTypeUrl(), TypeUrl.EDS.getTypeUrl()));
+        await().atMost(30, TimeUnit.SECONDS).until(() -> conversations.size() > 1 && conversations.get(1).isIdle());
+
+        return conversationInterceptor.getConversations().get(1);
     }
 
     @Test

--- a/wise-envoy-xds-e2e-tests/src/test/java/com/transferwise/envoy/e2e/delta/Envoy138Test.java
+++ b/wise-envoy-xds-e2e-tests/src/test/java/com/transferwise/envoy/e2e/delta/Envoy138Test.java
@@ -1,0 +1,15 @@
+package com.transferwise.envoy.e2e.delta;
+
+public class Envoy138Test extends EnvoyIntTest {
+
+    @Override
+    protected String getEnvoyImageName() {
+        return "envoyproxy/envoy:v1.38-latest";
+    }
+
+    @Override
+    protected boolean hasBrokenWildcardReconnect() {
+        return false;
+    }
+
+}

--- a/wise-envoy-xds-e2e-tests/src/test/java/com/transferwise/envoy/e2e/delta/EnvoyIntTest.java
+++ b/wise-envoy-xds-e2e-tests/src/test/java/com/transferwise/envoy/e2e/delta/EnvoyIntTest.java
@@ -1,11 +1,21 @@
 package com.transferwise.envoy.e2e.delta;
 
 import static com.transferwise.envoy.e2e.assertions.DeltaConversationAssert.DELTA_CONVERSATION;
+import static com.transferwise.envoy.e2e.configdump.EnvoyAdminClient.sneakyUnpack;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.transferwise.envoy.e2e.BaseEnvoyIntTest;
 import com.transferwise.envoy.e2e.assertions.DeltaConversationAssert;
 import com.transferwise.envoy.e2e.utils.ConversationLogger.Conversation;
+import com.transferwise.envoy.xds.TypeUrl;
+import io.envoyproxy.envoy.config.route.v3.RouteConfiguration;
+import io.envoyproxy.envoy.service.discovery.v3.DeltaDiscoveryRequest;
+import io.envoyproxy.envoy.service.discovery.v3.DeltaDiscoveryResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Predicate;
 import org.assertj.core.api.InstanceOfAssertFactory;
+import org.junit.jupiter.api.Test;
 
 
 public abstract class EnvoyIntTest extends BaseEnvoyIntTest<DeltaConversationAssert> {
@@ -23,5 +33,79 @@ public abstract class EnvoyIntTest extends BaseEnvoyIntTest<DeltaConversationAss
     @Override
     protected DeltaConversationAssert envoyAssertThat(Conversation conversation) {
         return DeltaConversationAssert.assertThat(conversation);
+    }
+
+    @Test
+    public void reconnectRemovalOrdering() throws IOException, InterruptedException {
+        Conversation reconnect = reconnectAfterRemovingBar(TypeUrl.RDS);
+        List<Object> messages = reconnect.getMessages();
+
+        int firstCdsResponse = indexOfDeltaResponse(messages, TypeUrl.CDS, response -> true);
+        assertThat(deltaResponseAt(messages, firstCdsResponse).getRemovedResourcesList()).doesNotContain("bar");
+
+        int rdsWithoutBar = indexOfDeltaResponse(messages, TypeUrl.RDS, response -> routeResponseDoesNotReferenceCluster(response, "bar"));
+        int rdsAck = indexOfDeltaAckForResponse(messages, rdsWithoutBar);
+        int cdsRemoval = indexOfDeltaResponse(messages, TypeUrl.CDS, response -> response.getRemovedResourcesList().contains("bar"));
+        int edsRemoval = optionalIndexOfDeltaResponse(messages, TypeUrl.EDS, response -> response.getRemovedResourcesList().contains("bar"));
+
+        assertThat(rdsAck).isLessThan(cdsRemoval);
+        if (edsRemoval != -1) {
+            assertThat(cdsRemoval).isLessThan(edsRemoval);
+        }
+    }
+
+    private int indexOfDeltaResponse(List<Object> messages, TypeUrl typeUrl, Predicate<DeltaDiscoveryResponse> predicate) {
+        for (int i = 0; i < messages.size(); i++) {
+            if (messages.get(i) instanceof DeltaDiscoveryResponse response
+                && response.getTypeUrl().equals(typeUrl.getTypeUrl())
+                && predicate.test(response)) {
+                return i;
+            }
+        }
+        throw new AssertionError("Did not find " + typeUrl + " DeltaDiscoveryResponse matching predicate");
+    }
+
+    private int optionalIndexOfDeltaResponse(List<Object> messages, TypeUrl typeUrl, Predicate<DeltaDiscoveryResponse> predicate) {
+        for (int i = 0; i < messages.size(); i++) {
+            if (messages.get(i) instanceof DeltaDiscoveryResponse response
+                && response.getTypeUrl().equals(typeUrl.getTypeUrl())
+                && predicate.test(response)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private int indexOfDeltaAckForResponse(List<Object> messages, int responseIndex) {
+        DeltaDiscoveryResponse response = deltaResponseAt(messages, responseIndex);
+        for (int i = responseIndex + 1; i < messages.size(); i++) {
+            if (messages.get(i) instanceof DeltaDiscoveryRequest request
+                && request.getTypeUrl().equals(response.getTypeUrl())
+                && request.getResponseNonce().equals(response.getNonce())) {
+                return i;
+            }
+        }
+        throw new AssertionError("Did not find ACK for " + response.getTypeUrl() + " nonce " + response.getNonce());
+    }
+
+    private DeltaDiscoveryResponse deltaResponseAt(List<Object> messages, int index) {
+        return (DeltaDiscoveryResponse) messages.get(index);
+    }
+
+    private boolean routeResponseDoesNotReferenceCluster(DeltaDiscoveryResponse response, String clusterName) {
+        List<RouteConfiguration> routeConfigurations = response.getResourcesList().stream()
+            .map(resource -> sneakyUnpack(resource.getResource(), RouteConfiguration.class))
+            .toList();
+
+        return !routeConfigurations.isEmpty()
+            && routeConfigurations.stream()
+                .noneMatch(routeConfiguration -> routeConfigReferencesCluster(routeConfiguration, clusterName));
+    }
+
+    private boolean routeConfigReferencesCluster(RouteConfiguration routeConfiguration, String clusterName) {
+        return routeConfiguration.getVirtualHostsList().stream()
+            .flatMap(virtualHost -> virtualHost.getRoutesList().stream())
+            .filter(route -> route.hasRoute())
+            .anyMatch(route -> route.getRoute().getCluster().equals(clusterName));
     }
 }

--- a/wise-envoy-xds-e2e-tests/src/test/java/com/transferwise/envoy/e2e/sotw/Envoy138Test.java
+++ b/wise-envoy-xds-e2e-tests/src/test/java/com/transferwise/envoy/e2e/sotw/Envoy138Test.java
@@ -1,0 +1,15 @@
+package com.transferwise.envoy.e2e.sotw;
+
+public class Envoy138Test extends EnvoyIntTest {
+
+    @Override
+    protected String getEnvoyImageName() {
+        return "envoyproxy/envoy:v1.38-latest";
+    }
+
+    @Override
+    protected boolean hasBrokenWildcardReconnect() {
+        return false;
+    }
+
+}


### PR DESCRIPTION
## Context

`DiscoveryServiceManager` sequences additions and removals to satisfy ADS make-before-break ordering. That ordering can be broken when an Envoy disconnects from ADS, resources change while it is disconnected, and then Envoy reconnects.

On reconnect, Envoy sends `initial_resource_versions` for resources it still has. Today we immediately respond to each discovery request with removals for stale resources. In practice Envoy requests CDS before RDS, so a stale cluster can be removed before the updated route that stops referencing it has been accepted. That can temporarily drop traffic with Envoy's `NC` ("no cluster") failure.

This PR fixes the Delta implementation only. SoTW removals are omissions from a full response, so preserving safe ordering there would require retaining or reconstructing old resource bodies, or delaying whole responses. The fix also relies on `delayUpdatesUntilAckOf` being configured, since that is the signal we use that Envoy has accepted the dependent initial config.

## Changes

When `delayUpdatesUntilAckOf` is set, Delta stale removals discovered from `initial_resource_versions` are deferred instead of being sent immediately.

After the configured type URL is ACKed for the first time, the manager flushes those deferred removals in `TypeUrl.REMOVE_ORDER`, waiting for each response to be ACKed before sending the next type's removals. Only after all deferred reconnect removals have been ACKed are queued network updates sent.

The implementation uses only resource names from `initial_resource_versions`; it does not rely on client-supplied versions as we do not track versions between client sessions.

## Tests

Added coverage for Delta reconnect removals to verify that:
  - stale `initial_resource_versions` removals are deferred when `delayUpdatesUntilAckOf` is configured
  - deferred removals are flushed in `TypeUrl.REMOVE_ORDER`
  - each deferred removal response is ACKed before the next type is flushed
  - queued network updates wait until all deferred reconnect removals have been sent and ACKed
  - removals are only sent for resources the client is subscribed to
  - without `delayUpdatesUntilAckOf`, removals keep the previous immediate behavior

Added e2e coverage for the Delta reconnect case.

Added Envoy 1.38 tests to keep ensure we test against modern envoy versions.
Updated test containers so it works on my machine.