### PR TITLE
[CONNECT-2772] Bump protobuf-java version to 3.25.X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.0.1] - 2026-08-19
+### Changed
+* Bump com.google.protobuf:protobuf-java from 3.21.12 to 3.25.9
+* Bump com.google.protobuf:protobuf-java-util from 3.21.12 to 3.25.9
+
 ## [1.0.0] - 2023-02-09
 ### Added
 * Disabled dependabot for envoy-api package

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0
+version=1.0.1

--- a/wise-envoy-xds-core/build.gradle
+++ b/wise-envoy-xds-core/build.gradle
@@ -20,7 +20,7 @@ pitest {
 }
 
 dependencies {
-    implementation 'com.google.protobuf:protobuf-java-util:3.21.12'
+    implementation 'com.google.protobuf:protobuf-java-util:3.25.9'
     implementation "com.google.guava:guava:31.1-jre"
     implementation 'io.grpc:grpc-stub:1.52.1'
     implementation 'javax.annotation:javax.annotation-api:1.3.2'

--- a/wise-envoy-xds-e2e-tests/build.gradle
+++ b/wise-envoy-xds-e2e-tests/build.gradle
@@ -12,8 +12,8 @@ dependencies {
     implementation "com.google.guava:guava:31.1-jre"
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     implementation 'com.github.spotbugs:spotbugs-annotations:4.7.3'
-    implementation 'com.google.protobuf:protobuf-java:3.21.12'
-    implementation 'com.google.protobuf:protobuf-java-util:3.21.9'
+    implementation 'com.google.protobuf:protobuf-java:3.25.9'
+    implementation 'com.google.protobuf:protobuf-java-util:3.25.9'
     implementation 'io.grpc:grpc-stub:1.52.1'
     implementation project(':wise-envoy-xds-core')
     implementation project(':wise-envoy-xds-example')

--- a/wise-envoy-xds-example/build.gradle
+++ b/wise-envoy-xds-example/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation "com.google.guava:guava:31.1-jre"
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     implementation 'com.github.spotbugs:spotbugs-annotations:4.7.3'
-    implementation 'com.google.protobuf:protobuf-java:3.21.12'
+    implementation 'com.google.protobuf:protobuf-java:3.25.9'
     implementation 'io.grpc:grpc-stub:1.52.1'
     implementation project(':wise-envoy-xds-core')
     implementation 'ch.qos.logback:logback-classic:1.4.5'


### PR DESCRIPTION
## Context

Bumping protobuf-java version. For full context see JIRA ticket.

https://transferwise.atlassian.net/browse/CONNECT-2772

In practice I think this will be a no op. EGADS already seems to be making this library use 3.25.X.
